### PR TITLE
Fix fp_lex object lex//1 non-terminal being called as a predicate

### DIFF
--- a/lex/src/fp_lex.lgt
+++ b/lex/src/fp_lex.lgt
@@ -23,7 +23,7 @@
 	:- info([
 		version is 1:0:0,
 		author is 'Lindsey Spratt',
-		date is 2022-02-22,
+		date is 2022-09-12,
 		comment is 'lexical analysis for the format-prolog source system.'
 	]).
 
@@ -66,7 +66,7 @@
 		open(File, read, S),
 		listify(Source, S),
 		close(S),
-		lex(Token_list, Source, []).
+		phrase(lex(Token_list), Source).
 
 	listify(L, S) :-
 		get_code(S, H),


### PR DESCRIPTION
This avoids the following warning:

```text
*     Non-terminal called as a predicate: lex//1
*       while compiling object fp_lex
*       in file /Users/pmoura/Documents/Logtalk/format-source/format/../lex/src/fp_lex.lgt between lines 65-69
```
